### PR TITLE
Fixes issue #2 and uses pre-defined arguments instead of **kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,23 @@ Decorators are added to route functions to include their URLs in the sitemap. Th
 def r_home():
     return flask.render_template("index.html")
 ```
+#### Additional Arguments
+You can pass optional arguments to the decorator to include additional information in the sitemap. Valid arguments are listed below, as defined by the [sitemap protocol](https://www.sitemaps.org/protocol.html): 
 
-You can pass arguments to the decorator to include additional information in the sitemap. Valid arguments are `lastmod` `changefreq` and `priority`.
+* `lastmod` - The date on which this page was last modified as a string in [W3C datetime](https://www.w3.org/TR/NOTE-datetime) format. (e.g. YYYY-MM-DD)
+
+* `changefreq` - How frequently the page is likely to change. Acceptable values are:
+
+    * always
+    * hourly
+    * daily
+    * weekly
+    * monthly
+    * yearly
+    * never
+
+* `priority` - The priority of this URL relative to other URLs on your site as a string, float, or integer. Valid values range from 0.0 to 1.0
+
 ```python
 @sitemapper.include(
     lastmod = "2022-02-08",
@@ -79,6 +94,7 @@ This example would appear in the sitemap as:
 </url>
 ```
 
+#### Notes
 For routes where multiple URL paths are defined, the sitemap will only include the last path.
 ```python
 @sitemapper.include()
@@ -96,7 +112,7 @@ def r_store():
 
 * Import the instance(s) when creating your flask app and initialize with `sitemapper.init_app(app)` ***after*** registering your blueprints.
 
-You can also add Flask endpoints to the sitemap by using their endpoint name as shown below. Keyword arguments can still be given after the endpoint name.
+You can also add Flask endpoints to the sitemap by using their endpoint name as shown below. Arguments can still be given after the endpoint name.
 ```python
 sitemapper.add_endpoint("r_contact", lastmod="2022-02-09")
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ def r_home():
     return flask.render_template("index.html")
 ```
 
-You can pass arguments to the decorator to include additional information in the sitemap. Whatever arguments you provide will be included in the URL entry as-is.
+You can pass arguments to the decorator to include additional information in the sitemap. Valid arguments are `lastmod` `changefreq` and `priority`.
 ```python
 @sitemapper.include(
     lastmod = "2022-02-08",

--- a/flask_sitemapper/sitemapper.py
+++ b/flask_sitemapper/sitemapper.py
@@ -1,4 +1,4 @@
-"""Provides the `Sitemapper` class"""
+"""Provides the `URL` and `Sitemapper` classes"""
 
 from functools import wraps
 from typing import Callable, Union
@@ -10,7 +10,45 @@ from .gzip import gzip_response
 from .templates import SITEMAP, SITEMAP_INDEX
 
 
+class URL:
+    """Stores a URL for the sitemap with its arguments"""
+
+    def __init__(
+        self,
+        endpoint,
+        scheme: str,
+        lastmod: str = None,
+        changefreq: str = None,
+        priority: Union[str, int, float] = None,
+        **kwargs,
+    ) -> None:
+        self.endpoint = endpoint
+        self.scheme = scheme
+        self.lastmod = lastmod
+        self.changefreq = changefreq
+        self.priority = priority
+
+    @property
+    def loc(self) -> str:
+        """Finds the URL from the endpoint name. Must be called within a request context"""
+        return url_for(self.endpoint, _external=True, _scheme=self.scheme)
+
+    @property
+    def xml(self) -> str:
+        """Generates a list of XML lines for this URL's sitemap entry"""
+        xml_lines = [f"<loc>{self.loc}</loc>"]
+        if self.lastmod:
+            xml_lines.append(f"<lastmod>{self.lastmod}</lastmod>")
+        if self.changefreq:
+            xml_lines.append(f"<changefreq>{self.changefreq}</changefreq>")
+        if self.priority:
+            xml_lines.append(f"<priority>{self.priority}</priority>")
+        return xml_lines
+
+
 class Sitemapper:
+    """The main class for this extension which manages and creates a sitemap"""
+
     def __init__(
         self, app: Flask = None, https: bool = True, master: bool = False, gzip: bool = False
     ) -> None:
@@ -19,9 +57,8 @@ class Sitemapper:
         self.template = SITEMAP_INDEX if master else SITEMAP
         self.gzip = gzip
 
-        # list of dicts storing the URLs with their parameters for the sitemap
-        # e.g. [{"loc": "https://example.com/about", "lastmod": "2022-05-22"}, ...]
-        self.urlset = []
+        # list of URL objects to list in the sitemap
+        self.urls = []
 
         # list of functions to run after extension initialization
         self.deferred_functions = []
@@ -84,15 +121,9 @@ class Sitemapper:
         else:
             endpoint = view_func
 
-        # find the URL using url_for and store it in a dict as "loc"
-        with self.app.test_request_context():
-            url = {"loc": url_for(endpoint, _external=True, _scheme=self.scheme)}
-
-        # add any provided parameters (e.g. lastmod) to the dict
-        url.update(kwargs)
-
-        # append the dict to self.urlset
-        self.urlset.append(url)
+        # create a URL object and append it to self.urls
+        url = URL(endpoint, self.scheme, **kwargs)
+        self.urls.append(url)
 
     def generate(self) -> Response:
         """Creates a Flask `Response` object for the XML sitemap"""
@@ -100,7 +131,7 @@ class Sitemapper:
         template = Environment(loader=BaseLoader).from_string(self.template)
 
         # render the template with the URLs and parameters
-        xml = template.render(urlset=self.urlset)
+        xml = template.render(urls=self.urls)
 
         # create a flask response
         response = Response(xml, content_type="application/xml")

--- a/flask_sitemapper/sitemapper.py
+++ b/flask_sitemapper/sitemapper.py
@@ -20,7 +20,6 @@ class URL:
         lastmod: str = None,
         changefreq: str = None,
         priority: Union[str, int, float] = None,
-        **kwargs,
     ) -> None:
         self.endpoint = endpoint
         self.scheme = scheme
@@ -80,12 +79,14 @@ class Sitemapper:
         # clear the deferred functions list
         self.deferred_functions.clear()
 
-    def include(self, **kwargs) -> Callable:
+    def include(
+        self, lastmod: str = None, changefreq: str = None, priority: Union[str, int, float] = None
+    ) -> Callable:
         """A decorator for view functions to add their URL to the sitemap"""
 
         # decorator that calls add_endpoint
         def decorator(func: Callable) -> Callable:
-            self.add_endpoint(func, **kwargs)
+            self.add_endpoint(func, lastmod=lastmod, changefreq=changefreq, priority=priority)
 
             @wraps(func)
             def wrapper(*args, **kwargs):
@@ -108,11 +109,21 @@ class Sitemapper:
             f"{func.__name__} in module {func.__module__} is not a registered view function"
         )
 
-    def add_endpoint(self, view_func: Union[Callable, str], **kwargs) -> None:
+    def add_endpoint(
+        self,
+        view_func: Union[Callable, str],
+        lastmod: str = None,
+        changefreq: str = None,
+        priority: Union[str, int, float] = None,
+    ) -> None:
         """Adds the URL of `view_func` to the sitemap with any provided arguments"""
         # if extension is not yet initialized, register this as a deferred function and return
         if not self.app:
-            self.deferred_functions.append(lambda s: s.add_endpoint(view_func, **kwargs))
+            self.deferred_functions.append(
+                lambda s: s.add_endpoint(
+                    view_func, lastmod=lastmod, changefreq=changefreq, priority=priority
+                )
+            )
             return
 
         # get the endpoint name of view_func
@@ -122,7 +133,7 @@ class Sitemapper:
             endpoint = view_func
 
         # create a URL object and append it to self.urls
-        url = URL(endpoint, self.scheme, **kwargs)
+        url = URL(endpoint, self.scheme, lastmod=lastmod, changefreq=changefreq, priority=priority)
         self.urls.append(url)
 
     def generate(self) -> Response:

--- a/flask_sitemapper/templates.py
+++ b/flask_sitemapper/templates.py
@@ -2,7 +2,7 @@
 
 SITEMAP = """<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {%- for url in urlset %}
+  {%- for url in urls %}
   <url>
     {%- for line in url.xml %}
     {{ line|safe }}
@@ -13,7 +13,7 @@ SITEMAP = """<?xml version="1.0" encoding="utf-8"?>
 
 SITEMAP_INDEX = """<?xml version="1.0" encoding="utf-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {%- for url in urlset %}
+  {%- for url in urls %}
   <sitemap>
     {%- for line in url.xml %}
     {{ line|safe }}

--- a/flask_sitemapper/templates.py
+++ b/flask_sitemapper/templates.py
@@ -4,8 +4,8 @@ SITEMAP = """<?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {%- for url in urlset %}
   <url>
-    {%- for arg, value in url.items() %}
-    <{{arg}}>{{ value }}</{{arg}}>
+    {%- for line in url.xml %}
+    {{ line|safe }}
     {%- endfor %}
   </url>
   {%- endfor %}
@@ -15,8 +15,8 @@ SITEMAP_INDEX = """<?xml version="1.0" encoding="utf-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {%- for url in urlset %}
   <sitemap>
-    {%- for arg, value in url.items() %}
-    <{{arg}}>{{ value }}</{{arg}}>
+    {%- for line in url.xml %}
+    {{ line|safe }}
     {%- endfor %}
   </sitemap>
   {%- endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flask-sitemapper"
-version = "1.4.1"
+version = "1.5.0"
 description = "Flask extension for generating XML sitemaps"
 authors = ["h-janes <dev@hjanes.com>"]
 license = "MIT"

--- a/tests/test_server_name.py
+++ b/tests/test_server_name.py
@@ -1,0 +1,58 @@
+import flask
+
+from flask_sitemapper import Sitemapper
+
+# ----------------- TEST APP -----------------
+
+sitemapper = Sitemapper()
+app = flask.Flask(__name__)
+app.config["SERVER_NAME"] = "example.com"
+sitemapper.init_app(app)
+
+
+@sitemapper.include(lastmod="2022-02-01", changefreq="monthly")
+@app.route("/")
+def r_home():
+    return "<h1>Home</h1>"
+
+
+@app.route("/sitemap.xml")
+def r_sitemap():
+    return sitemapper.generate()
+
+
+# ----------------- END TEST APP -----------------
+
+
+def test_running():
+    with app.test_client() as test_client:
+        response = test_client.get("/")
+        assert response.text == "<h1>Home</h1>"
+
+
+def test_status_code():
+    with app.test_client() as test_client:
+        response = test_client.get("/sitemap.xml")
+        assert response.status_code == 200
+
+
+def test_mimetype():
+    with app.test_client() as test_client:
+        response = test_client.get("/sitemap.xml")
+        assert response.mimetype == "application/xml"
+
+
+def test_xml():
+    with app.test_client() as test_client:
+        response = test_client.get("/sitemap.xml")
+        assert (
+            response.text
+            == """<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+    <lastmod>2022-02-01</lastmod>
+    <changefreq>monthly</changefreq>
+  </url>
+</urlset>"""
+        )


### PR DESCRIPTION
* To fix #2, URLs in the `Sitemapper` urls list are now stored as new `URL` objects rather than dicts, with methods that generate their URL loc and XML during sitemap generation. These changes are in `sitemapper.py` and `templates.py`

* The `Sitemapper` methods `include` and `add_endpoint` previously accepted `**kwargs` but now only accept the pre-defined keyword arguments `lastmod` `changefreq`and `priority`

* `README.md` has been improved and updated to reflect these changes.

* A test has been added in `test_server_name.py` to ensure that the extension respects the `SERVER_NAME` if it is defined in the Flask configuration.

* The version number has been incremented to 1.5.0 to reflect these changes and prepare for the next release.